### PR TITLE
Broken links to example keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Source `helper.h` near the top of your `.keymap` file. Optionally, source `key-l
 ```
 
 The following subsections describe the available helpers. See the
-[example configuration](example/zmk-config/config/cradio.keymap) or my
+[example configuration](examples/zmk-config/config/cradio.keymap) or my
 [personal zmk-config](https://github.com/urob/zmk-config/blob/main/config/base.keymap) for a
 demonstration.
 

--- a/docs/core_helpers.md
+++ b/docs/core_helpers.md
@@ -173,7 +173,7 @@ ZMK_CONDITIONAL_LAYER(its_magic, 1 2, 3)
 ```
 
 Mind that ZMK's layer numbering starts at 0. One can use layer definitions, as demonstrated in this
-[../example/zmk-config/config/cradio.keymap](example), to simplify life.
+[example](../examples/zmk-config/config/cradio.keymap), to simplify life.
 
 ## ZMK_LAYER
 

--- a/examples/zmk-config/config/cradio.keymap
+++ b/examples/zmk-config/config/cradio.keymap
@@ -62,7 +62,7 @@ ZMK_MACRO(win_sleep,
 ZMK_UNICODE_SINGLE(euro_sign, N2, N0, A, C)  // €
 
 // replace a/o/u/s with German umlauts when NAV and NUM are held jointly
-ZMK_CONDITIONAL_LAYER(NAV NUM, GER)
+ZMK_CONDITIONAL_LAYER(type_german, NAV NUM, GER)
 
 // combos
 ZMK_COMBO(sleep,    &win_sleep,  RT3 RT4, NAV)  // put Windows to sleep, only active on NAV layer

--- a/examples/zmk-config/config/cradio.keymap
+++ b/examples/zmk-config/config/cradio.keymap
@@ -62,7 +62,7 @@ ZMK_MACRO(win_sleep,
 ZMK_UNICODE_SINGLE(euro_sign, N2, N0, A, C)  // €
 
 // replace a/o/u/s with German umlauts when NAV and NUM are held jointly
-ZMK_CONDITIONAL_LAYER(type_german, NAV NUM, GER)
+ZMK_CONDITIONAL_LAYER(ger, NAV NUM, GER)
 
 // combos
 ZMK_COMBO(sleep,    &win_sleep,  RT3 RT4, NAV)  // put Windows to sleep, only active on NAV layer


### PR DESCRIPTION
Change example to examples in the file path.

Also changed ZMK_CONDITIONAL_LAYER in example to new syntax.