### PR TITLE
fix(polish): name for pl_a_ogonek

### DIFF
--- a/include/zmk-helpers/unicode-chars/polish.dtsi
+++ b/include/zmk-helpers/unicode-chars/polish.dtsi
@@ -1,6 +1,6 @@
 /* polish letters */
 
-ZMK_UNICODE_PAIR(pl_e_ogonek,     N0, N1, N0, N5,     N0, N1, N0, N4) // ą/Ą
+ZMK_UNICODE_PAIR(pl_a_ogonek,     N0, N1, N0, N5,     N0, N1, N0, N4) // ą/Ą
 ZMK_UNICODE_PAIR(pl_c_acute,      N0, N1, N0, N7,     N0, N1, N0, N6) // ć/Ć
 ZMK_UNICODE_PAIR(pl_e_ogonek,     N0, N1, N1, N9,     N0, N1, N1, N8) // ę/Ę
 ZMK_UNICODE_PAIR(pl_l_stroke,     N0, N1, N4, N2,     N0, N1, N4, N1) // ł/Ł


### PR DESCRIPTION
This change updates the name for Unicode "ą/Ą" characters.