### PR TITLE
Add Spanish u diéresis (ü)

### DIFF
--- a/include/zmk-helpers/unicode-chars/spanish.dtsi
+++ b/include/zmk-helpers/unicode-chars/spanish.dtsi
@@ -6,5 +6,6 @@ ZMK_UNICODE_PAIR(es_e_acute,        N0, N0, E, N9,   N0, N0, C, N9)  // é/É
 ZMK_UNICODE_PAIR(es_i_acute,        N0, N0, E, D,   N0, N0, C, D)  // í/Í
 ZMK_UNICODE_PAIR(es_o_acute,        N0, N0, F, N3,   N0, N0, D, N3)  // ó/Ó 
 ZMK_UNICODE_PAIR(es_u_acute,        N0, N0, F, A,   N0, N0, D, A)  // ú/Ú
+ZMK_UNICODE_PAIR(es_u_dieresis,     N0, N0, F, C,   N0, N0, D, C)  // ü/Ü
 ZMK_UNICODE_PAIR(es_n_tilde,        N0, N0, F, N1,  N0, N0, D, N1)  // ñ/Ñ 
 


### PR DESCRIPTION
Small PR to add the Spanish ü (known as "la diéresis", used in words like "bilingüe") to the Spanish unicode list. This can be achieved by also importing `german.dtsi` and using `&de_ue`, but this is more convenient and semantically appropriate for Spanish.