### PR TITLE
Fix adv360 layout mapping

### DIFF
--- a/include/zmk-helpers/key-labels/adv360.h
+++ b/include/zmk-helpers/key-labels/adv360.h
@@ -2,13 +2,13 @@
  ╭────────────────────────────┬────────────────────────────╮ ╭────────────────────────────┬────────────────────────────╮
  │  0   1   2   3   4   5   6 │  7   8   9  10  11  12  13 │ │ LN5 LN4 LN3 LN2 LN1 LN0 -- │ --  RN0 RN1 RN2 RN3 RN4 RN5│
  │ 14  15  16  17  18  19  20 │ 21  22  23  24  25  26  27 │ │ LT5 LT4 LT3 LT2 LT1 LT0 -- │ --  RT0 RT1 RT2 RT3 RT4 RT5│
- │ 28  29  30  31  32  33  34 │ 35  36  37  38  39  40  41 │ │ LM5 LM4 LM3 LM2 LM1 LM0 -- │ --  RM0 RM1 RM2 RM3 RM4 RM5│
- │ 42  43  44  45  46  47 ╭───┴───╮ 48  49  50  51  52  53 │ │ LB5 LB4 LB3 LB2 LB1 LB0╭───┴───╮ RB0 RB1 RB2 RB3 RB4 RB5│
- │ 54  55  56  57  58╭────╯       ╰────╮59  60  61  62  63 │ │ --  --  --  --  --╭────╯       ╰────╮--  --  --  --  -- │
+ │ 28  29  30  31  32  33  34 │ 39  40  41  42  43  44  45 │ │ LM5 LM4 LM3 LM2 LM1 LM0 -- │ --  RM0 RM1 RM2 RM3 RM4 RM5│
+ │ 46  47  48  49  50  51 ╭───┴───╮ 54  55  56  57  58  59 │ │ LB5 LB4 LB3 LB2 LB1 LB0╭───┴───╮ RB0 RB1 RB2 RB3 RB4 RB5│
+ │ 60  61  62  63  64╭────╯       ╰────╮71  72  73  74  75 │ │ --  --  --  --  --╭────╯       ╰────╮--  --  --  --  -- │
  ╰───────────────────┼────────┬────────┼───────────────────╯ ╰───────────────────┼────────┬────────┼───────────────────╯
-                 ╭───╯ 64  65 │ 66  67 ╰───╮                                 ╭───╯ --  -- │ --  -- ╰───╮
-                 │ 68  69  70 │ 71  72  73 │                                 │ LH1 LH0 -- │ --  RH0 RH1│
-                 ╰───────╮ 74 │ 75 ╭───────╯                                 ╰───────╮ -- │ -- ╭───────╯
+                 ╭───╯ 35  36 │ 37  38 ╰───╮                                 ╭───╯ --  -- │ --  -- ╰───╮
+                 │ 65  66  67 │ 68  69  70 │                                 │ LH1 LH0 -- │ --  RH0 RH1│
+                 ╰───────╮ 52 │ 53 ╭───────╯                                 ╰───────╮ -- │ -- ╭───────╯
                          ╰────┴────╯                                                 ╰────┴────╯ */
 
 #pragma once
@@ -48,32 +48,32 @@
 #define LM4 29
 #define LM5 28
 
-#define RM0 36  // right-middle row
-#define RM1 37
-#define RM2 38
-#define RM3 39
-#define RM4 40
-#define RM5 41
+#define RM0 40  // right-middle row
+#define RM1 41
+#define RM2 42
+#define RM3 43
+#define RM4 44
+#define RM5 45
 
-#define LB0 47  // left-bottom row
-#define LB1 46
-#define LB2 45
-#define LB3 44
-#define LB4 43
-#define LB5 42
+#define LB0 51  // left-bottom row
+#define LB1 50
+#define LB2 49
+#define LB3 48
+#define LB4 47
+#define LB5 46
 
-#define RB0 48  // right-bottom row
-#define RB1 49
-#define RB2 50
-#define RB3 51
-#define RB4 52
-#define RB5 53
+#define RB0 54  // right-bottom row
+#define RB1 55
+#define RB2 56
+#define RB3 57
+#define RB4 58
+#define RB5 59
 
-#define LH0 70  // left thumb keys
-#define LH1 69
-#define LH2 74
+#define LH0 66  // left thumb keys
+#define LH1 65
+#define LH2 67
 
-#define RH0 72  // right thumb keys
-#define RH1 73
-#define RH2 75
+#define RH0 69  // right thumb keys
+#define RH1 70
+#define RH2 68
 


### PR DESCRIPTION
Somehow the mapping for the Kinesis Advantage 360 Pro was wrong.

This was mainly (only?) visible because some combos (especially starting with the ones on the right side) did not work.

This commit/PR fixes that. It also treats the thumb keys in the order LH1, LH0, LH2; due to the physical arrangement of the keys (i.e. the thumb cluster is farther away than on these famous custom build keyboards).

Nevertheless: I dont know if you want to merge this, but even if not, anybody with a Advantage 360 would probably have an "advantage" when trying out your (awesome!) take on a keyboard config (and discovering this in the rejected PRs ;) ; that's totally fine).